### PR TITLE
Use println instead of outdated outln

### DIFF
--- a/tests/fundamental/hello_world.fer
+++ b/tests/fundamental/hello_world.fer
@@ -1,3 +1,3 @@
 let io = import('std/io');
 
-io.outln('hello world!');
+io.println('hello world!');


### PR DESCRIPTION
I tried to run hello_world.fer test and got this:

```
.../Feral/tests/fundamental/hello_world.fer 3[9]: error: function 'outln' does not exist for type: module
io.outln('hello world!');
        ^
```

It's not hard to guess that `outln` probably was there first but then deprecated in favor of `println`. 
Btw, why `println`? Does Rust influence you? 😉 