### PR TITLE
Make nearest_mult8 implementation concise

### DIFF
--- a/src/VM/Memory.cpp
+++ b/src/VM/Memory.cpp
@@ -13,72 +13,7 @@ namespace mem
 {
 size_t nearest_mult8( size_t sz )
 {
-	if( sz > 512 ) return sz;
-	else if( sz >=   1 && sz <=   8 ) return   8;
-	else if( sz >=   9 && sz <=  16 ) return  16;
-	else if( sz >=  17 && sz <=  24 ) return  24;
-	else if( sz >=  25 && sz <=  32 ) return  32;
-	else if( sz >=  33 && sz <=  40 ) return  40;
-	else if( sz >=  41 && sz <=  48 ) return  48;
-	else if( sz >=  49 && sz <=  56 ) return  56;
-	else if( sz >=  57 && sz <=  64 ) return  64;
-	else if( sz >=  65 && sz <=  72 ) return  72;
-	else if( sz >=  73 && sz <=  80 ) return  80;
-	else if( sz >=  81 && sz <=  88 ) return  88;
-	else if( sz >=  89 && sz <=  96 ) return  96;
-	else if( sz >=  97 && sz <= 104 ) return 104;
-	else if( sz >= 105 && sz <= 112 ) return 112;
-	else if( sz >= 113 && sz <= 120 ) return 120;
-	else if( sz >= 121 && sz <= 128 ) return 128;
-	else if( sz >= 129 && sz <= 136 ) return 136;
-	else if( sz >= 137 && sz <= 144 ) return 144;
-	else if( sz >= 145 && sz <= 152 ) return 152;
-	else if( sz >= 153 && sz <= 160 ) return 160;
-	else if( sz >= 161 && sz <= 168 ) return 168;
-	else if( sz >= 169 && sz <= 176 ) return 176;
-	else if( sz >= 177 && sz <= 184 ) return 184;
-	else if( sz >= 185 && sz <= 192 ) return 192;
-	else if( sz >= 193 && sz <= 200 ) return 200;
-	else if( sz >= 201 && sz <= 208 ) return 208;
-	else if( sz >= 209 && sz <= 216 ) return 216;
-	else if( sz >= 217 && sz <= 224 ) return 224;
-	else if( sz >= 225 && sz <= 232 ) return 232;
-	else if( sz >= 233 && sz <= 240 ) return 240;
-	else if( sz >= 241 && sz <= 248 ) return 248;
-	else if( sz >= 249 && sz <= 256 ) return 256;
-	else if( sz >= 257 && sz <= 264 ) return 264;
-	else if( sz >= 265 && sz <= 272 ) return 272;
-	else if( sz >= 273 && sz <= 280 ) return 280;
-	else if( sz >= 281 && sz <= 288 ) return 288;
-	else if( sz >= 289 && sz <= 296 ) return 296;
-	else if( sz >= 297 && sz <= 304 ) return 304;
-	else if( sz >= 305 && sz <= 312 ) return 312;
-	else if( sz >= 313 && sz <= 320 ) return 320;
-	else if( sz >= 321 && sz <= 328 ) return 328;
-	else if( sz >= 329 && sz <= 336 ) return 336;
-	else if( sz >= 337 && sz <= 344 ) return 344;
-	else if( sz >= 345 && sz <= 352 ) return 352;
-	else if( sz >= 353 && sz <= 360 ) return 360;
-	else if( sz >= 361 && sz <= 368 ) return 368;
-	else if( sz >= 369 && sz <= 376 ) return 376;
-	else if( sz >= 377 && sz <= 384 ) return 384;
-	else if( sz >= 385 && sz <= 392 ) return 392;
-	else if( sz >= 393 && sz <= 400 ) return 400;
-	else if( sz >= 401 && sz <= 408 ) return 408;
-	else if( sz >= 409 && sz <= 416 ) return 416;
-	else if( sz >= 417 && sz <= 424 ) return 424;
-	else if( sz >= 425 && sz <= 432 ) return 432;
-	else if( sz >= 433 && sz <= 440 ) return 440;
-	else if( sz >= 441 && sz <= 448 ) return 448;
-	else if( sz >= 449 && sz <= 456 ) return 456;
-	else if( sz >= 457 && sz <= 464 ) return 464;
-	else if( sz >= 465 && sz <= 472 ) return 472;
-	else if( sz >= 473 && sz <= 480 ) return 480;
-	else if( sz >= 481 && sz <= 488 ) return 488;
-	else if( sz >= 489 && sz <= 496 ) return 496;
-	else if( sz >= 497 && sz <= 504 ) return 504;
-	else if( sz >= 505 && sz <= 512 ) return 512;
-	return sz;
+	return ( sz > 512 ) ? sz : ( sz + 7 ) & ~7;
 }
 }
 


### PR DESCRIPTION
Fixes #2

How to test

- MEM_PROFILE=true cmake ..
- feral tests/facto_iterate.fer > facto_iterate.out

I got the following output → https://gist.github.com/vitkarpov/46a3a41d9c511239e38b774e67511083 with both versions (before & after changes applied).