### PR TITLE
Add os.mv()

### DIFF
--- a/src/std/os.cpp
+++ b/src/std/os.cpp
@@ -304,8 +304,8 @@ var_base_t * os_mv( vm_state_t & vm, const fn_data_t & fd)
     const char * firstParam  = STR(fd.args[ 1 ])->get().c_str();
     const char * secondParam = STR(fd.args[ 2 ])->get().c_str();
 
-    if (std::rename(firstParam, secondParam) < 0) {
-        vm.fail( fd.src_id, fd.idx, strerror(errno) );
+    if ( std::rename( firstParam, secondParam ) < 0) {
+        vm.fail( fd.src_id, fd.idx, strerror( errno ) );
         return nullptr;
     }
 
@@ -333,7 +333,7 @@ INIT_MODULE( os )
 	src->add_native_fn( "rm", os_rm, 1, true );
 
 	src->add_native_fn( "cp", os_copy, 2, true );
-    src->add_native_fn( "mv", os_mv, 2, true );
+    src->add_native_fn( "mv", os_mv, 2 );
 
 	src->add_native_fn( "chmod_native", os_chmod, 3 );
 

--- a/src/std/os.cpp
+++ b/src/std/os.cpp
@@ -287,6 +287,31 @@ var_base_t * os_chmod( vm_state_t & vm, const fn_data_t & fd )
 	return make< var_int_t >( exec_internal( cmd ) );
 }
 
+var_base_t * os_mv( vm_state_t & vm, const fn_data_t & fd)
+{
+    if ( !fd.args[ 1 ]->istype< var_str_t >() ) {
+        vm.fail( fd.src_id, fd.idx, "expected string argument for from, found: %s",
+            vm.type_name( fd.args[ 1 ] ).c_str() );
+        return nullptr;
+    }
+
+    if ( !fd.args[ 2 ]->istype< var_str_t >() ) {
+        vm.fail( fd.src_id, fd.idx, "expected string argument for to, found: %s",
+            vm.type_name( fd.args[ 2 ] ).c_str() );
+        return nullptr;
+    }
+
+    const char * firstParam  = STR(fd.args[ 1 ])->get().c_str();
+    const char * secondParam = STR(fd.args[ 2 ])->get().c_str();
+
+    if (std::rename(firstParam, secondParam) < 0) {
+        vm.fail( fd.src_id, fd.idx, strerror(errno) );
+        return nullptr;
+    }
+
+    return make< var_int_t >( 0 );
+}
+
 INIT_MODULE( os )
 {
 	var_src_t * src = vm.current_source();
@@ -308,6 +333,7 @@ INIT_MODULE( os )
 	src->add_native_fn( "rm", os_rm, 1, true );
 
 	src->add_native_fn( "cp", os_copy, 2, true );
+    src->add_native_fn( "mv", os_mv, 2, true );
 
 	src->add_native_fn( "chmod_native", os_chmod, 3 );
 

--- a/tests/std/os.fer
+++ b/tests/std/os.fer
@@ -25,6 +25,10 @@ assert(os.get_cwd() == cwd);
 let dir = '__testdir__';
 os.mkdir(dir);
 assert(fs.exists(dir));
+os.mv(dir, '__moved_testdir__');
+assert(fs.exists('__moved_testdir__'));
+assert(!fs.exists(dir));
+os.mv('__moved_testdir__', dir);
 os.rm(dir);
 assert(!fs.exists(dir));
 


### PR DESCRIPTION
Add `os.mv()`

Usage:

```
let os = import('std/os');

os.mv('oldname', 'newname');
```

The script will be stopped with an error if the file cannot be moved.